### PR TITLE
Use ShortTimeFormat instead of AM-Designator

### DIFF
--- a/src/CronExpressions/CronExpressionQuickInfoSource.cs
+++ b/src/CronExpressions/CronExpressionQuickInfoSource.cs
@@ -85,7 +85,7 @@ namespace CronExpressions
             {
                 message = ExpressionDescriptor.GetDescription(expression, new Options
                 {
-                    Use24HourTimeFormat = DateTimeFormatInfo.CurrentInfo.AMDesignator == "",
+                    Use24HourTimeFormat = DateTimeFormatInfo.CurrentInfo.ShortTimePattern.Contains("H"),
                     ThrowExceptionOnParseError = false,
                     Verbose = true,
                 });


### PR DESCRIPTION
The AMDesignator does not work on my Windows machine.

My language is ENG with Format in Danish.

Looking at ShortTimePattern and if there is a "H" should indicate if the desired hour format is 24h